### PR TITLE
PostgresCluster full backup should not run at the same time as incremental

### DIFF
--- a/crunchydb/high-availablility/PostgresCluster.yaml
+++ b/crunchydb/high-availablility/PostgresCluster.yaml
@@ -37,8 +37,10 @@ spec:
       repos:
       - name: repo1
         schedules:
-          full: 0 1 * * *
-          incremental: 0 */4 * * *
+          # Full backup every day at 8:00am UTC
+          full: "0 8 * * *"
+          # Incremental backup every 4 hours, except at 8am UTC (when the full backup is running)
+          incremental: "0 0,4,12,16,20 * * *"
         volume:
           volumeClaimSpec:
             accessModes:


### PR DESCRIPTION
The settings in the example are causing the full backup job to fail a couple of times before succeeding, as the lock is taken by the incremental backup